### PR TITLE
Url previews

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'figaro'
 
 gem 'pundit'
 
+gem 'querystring'
+gem 'embedly'
 # HAML for markup
 gem 'haml'
 gem 'bootstrap-sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,10 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    embedly (1.9.1)
+      json
+      oauth
+      querystring
     erubis (2.7.0)
     execjs (2.5.2)
     figaro (1.0.0)
@@ -92,10 +96,12 @@ GEM
     multi_json (1.11.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    oauth (0.4.7)
     orm_adapter (0.5.0)
     pg (0.18.2)
     pundit (1.0.0)
       activesupport (>= 3.0.0)
+    querystring (0.1.0)
     rack (1.6.2)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -176,12 +182,14 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
   devise
+  embedly
   figaro
   haml
   jbuilder (~> 2.0)
   jquery-rails
   pg
   pundit
+  querystring
   rails (= 4.2.1)
   rails_12factor
   sass-rails (~> 5.0)

--- a/app/helpers/bookmarks_helper.rb
+++ b/app/helpers/bookmarks_helper.rb
@@ -1,2 +1,12 @@
+require 'embedly'
+require 'json'
+
 module BookmarksHelper
+
+  def embed(url)
+    embedly_api = Embedly::API.new :key => ENV['EMBEDLY_API']
+    obj = embedly_api.oembed :url => url
+    return obj[0].marshal_dump
+  end
+
 end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -2,4 +2,14 @@ class Bookmark < ActiveRecord::Base
   belongs_to :topic
   belongs_to :user
   has_many :likes, dependent: :destroy
+
+  before_create :http_url
+
+  private
+
+    def http_url
+      if self.url[0..6] != 'http://' || self.url[0..7] != 'https://'
+        self.url = self.url.prepend('http://')
+      end
+    end
 end

--- a/app/views/topics/_bookmarks.html.haml
+++ b/app/views/topics/_bookmarks.html.haml
@@ -1,7 +1,11 @@
 - record.bookmarks.each do |bookmark|
+  - bookmark_title = bookmark.url.split('.')[1]
   .col-md-3.bookmark-loop
     .bookmark-box
-      = bookmark.url
+      = link_to "#{bookmark.url}" do
+        %h4
+          = bookmark_title
+      = embed(bookmark.url)[:description].truncate(90)
       - if policy(Like.new).create?
         = render partial: 'likes/like', locals: { bookmark: bookmark }
       - if policy(bookmark).edit?


### PR DESCRIPTION
Creates content previews using the Embedly API. I would, however, like to change some of this implementation. It could be simplified by having the form validate the URL so it can only be submitted if it includes http / https.